### PR TITLE
Fix video randomization in static export

### DIFF
--- a/components/hero.tsx
+++ b/components/hero.tsx
@@ -1,23 +1,29 @@
 "use client"
+import { useEffect, useState } from 'react'
 import VideoContainer from './video-banner'
 
-// Function to return a random video from the available videos
-function getRandomVideo() {
-  const videos = [
-    // "backgrounds/office-group.mp4",
-    // "backgrounds/office-wood.mp4",
-    // "backgrounds/office-phone.mp4",
-    // "backgrounds/office-toghether.mp4",
-    "backgrounds/office-agreement.mp4",
-    // "backgrounds/network-blacklines.mp4",
-  ];
+const videos = [
+  // "backgrounds/office-group.mp4",
+  // "backgrounds/office-wood.mp4",
+  // "backgrounds/office-phone.mp4",
+  // "backgrounds/office-toghether.mp4",
+  "backgrounds/office-agreement.mp4",
+  // "backgrounds/network-blacklines.mp4",
+]
 
-  return videos[Math.floor(Math.random() * videos.length)];
+function getRandomVideo() {
+  return videos[Math.floor(Math.random() * videos.length)]
 }
 
 export default function Hero() {
+  const [videoSrc, setVideoSrc] = useState<string>(videos[0])
+
+  useEffect(() => {
+    setVideoSrc(getRandomVideo())
+  }, [])
+
   return (
-    <VideoContainer videoSrc={getRandomVideo()}>
+    <VideoContainer videoSrc={videoSrc}>
       <div className='text-center'>
         <h1 className="text-3xl md:text-5xl text-white font-extrabold drop-shadow-md tracking-tighter mb-4" data-aos="zoom-in">
           Transforming <br />


### PR DESCRIPTION
## Summary
- randomize hero banner video on the client using React state

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68505d2ce204832b9539796a1be8e633

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved video selection in the Hero section so that a random video is chosen once when the page loads, rather than changing on every render. This results in a more consistent user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->