### PR TITLE
Update home redirect to use browser language

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,14 +1,16 @@
 "use client"
-import { useEffect } from 'react';
-import { useRouter } from 'next/navigation';
+import { useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+import { detectBrowserLocale } from '@/lib/seo-i18n'
 
 export default function Home() {  
-  const router = useRouter();
+  const router = useRouter()
 
   useEffect(() => {
-    // Redirecionar para a página localizada em inglês
-    router.replace('/en');
-  }, [router]);
+    // Detect browser language and redirect accordingly
+    const locale = detectBrowserLocale()
+    router.replace(`/${locale}`)
+  }, [router])
 
   // Página de loading simples
   return (


### PR DESCRIPTION
## Summary
- detect the browser's preferred language on the home page and redirect users to the matching locale

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6865d41ecd04832ba7a487bbc8c27962